### PR TITLE
Strip sensor names off the device name prefix; better error handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -156,7 +156,7 @@ function register_button(button) {
     };
 
     //Setup config and destination for button press
-    obj.name = button.name + " Button Action";
+    obj.name = "Button Action";
     obj.state_topic = buttontopic + "/action";
     obj.unique_id = "Flic_" + button.serialNumber + "_action";
 
@@ -167,7 +167,7 @@ function register_button(button) {
     });
 
 	// Setup config and destination for button state
-	obj.name = button.name + " Button State";
+	obj.name = "Button State";
 	obj.state_topic = buttontopic + "/state";
 	obj.unique_id = "Flic_" + button.serialNumber + "_state";
 
@@ -178,7 +178,7 @@ function register_button(button) {
 	});
 
     //Setup config and destination for battery level report
-    obj.name = button.name + " Battery Level";
+    obj.name = "Battery Level";
     obj.state_topic = buttontopic + "/battery";
     obj.unique_id = "Flic_" + button.serialNumber + "_battery";
     obj.device_class = "battery";

--- a/main.js
+++ b/main.js
@@ -210,15 +210,18 @@ function register_allbuttons(){
 //This runs on startup, it performs the actual "discovery" announcement for 
 //HomeAssistant to add the device to its inventory
 mqtt.on('connected', function(){
+	console.log("\n'Connected' event\n");
 	register_allbuttons();
 });
 
 // Added by heroash88 to reconnect if MQTT server goes down
 mqtt.on('disconnected', function() {
+	console.log("\n'Disconnected' event\n");
 	mqtt.connect();
 });
 
 mqtt.on('error', function () {
+	console.log("\n'Error' event\n");
 	setTimeout(function () {
 		throw new Error("Crashed")
 	}, 1000);

--- a/main.js
+++ b/main.js
@@ -218,12 +218,10 @@ mqtt.on('disconnected', function() {
 	mqtt.connect();
 });
 
-mqtt.on('error', function() {
-  setTimeout(function (){
-    mqtt.connect();
-  }, 1000);
+mqtt.on('error', function () {
+	setTimeout(function () {
+		throw new Error("Crashed")
+	}, 1000);
 });
-
-
 
 mqtt.connect();


### PR DESCRIPTION
- Fixes #3
- Eliminates the need to restart the module in Flic Hub SDK when the MQTT server is not available for a minute. Previous behaviour - this error was reported: flic hub fatal error: uncaught: 'cannot push beyond allocated stack' (Flic Hub Firmware: 3.0.12) - see https://community.flic.io/topic/18257/cannot-push-beyond-allocated-stack-fatal-error